### PR TITLE
Add minPeriod property for less frequent updates

### DIFF
--- a/timeago.js
+++ b/timeago.js
@@ -7,6 +7,7 @@ module.exports = React.createClass(
   { displayName: 'Time-Ago'
   , getDefaultProps: function(){
       return { live: true
+             , minPeriod: 0
              , component: 'span'
              , formatter: function (value, unit, suffix) {
                  if(value !== 1){
@@ -43,7 +44,7 @@ module.exports = React.createClass(
       }
 
       if(!!period){
-        setTimeout(this.tick, period)
+        setTimeout(this.tick, Math.max(this.props.minPeriod, period));
       }
 
       if(!refresh){


### PR DESCRIPTION
Adding a new minPeriod property to the setTimeout() function, so we can achieve less frequent updates of the elements.
This was done due to performance reasons as we needed only updates once per minute and not once per second.