### PR TITLE
Clear the timeout when the component is unmounted

### DIFF
--- a/timeago.js
+++ b/timeago.js
@@ -16,11 +16,22 @@ module.exports = React.createClass(
                }
              }
     }
+  , getInitialState: function () {
+    return {
+      timeoutId: 0
+    }
+  }
   , componentDidMount: function(){
       if(this.props.live) {
         this.tick(true)
       }
     }
+  , componentWillUnmount: function() {
+    if(this.state.timeoutId) {
+      clearTimeout(this.state.timeoutId)
+      this.state.timeoutId = undefined
+    }
+  }
   , tick: function(refresh){
       if(!this.isMounted()){
         return
@@ -43,7 +54,7 @@ module.exports = React.createClass(
       }
 
       if(!!period){
-        setTimeout(this.tick, period)
+        this.setState({'timeoutId' : setTimeout(this.tick, period)})
       }
 
       if(!refresh){


### PR DESCRIPTION
Not clearing the timeout was causing build scripts to hang as we were generating after we included readt-timeago in one of our components even after we had unmounted the components. Clearing the timeout as the component is unmounted fixes this issue. This is the the better way to do it using state.