### PR TITLE
Support React 0.14.0 alphas/betas/rcs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/nmn/react-timeago",
   "peerDependencies": {
-    "react": ">=0.12.0"
+    "react": ">=0.12.0 || ^0.14.0-alpha"
   },
   "devDependencies": {
     "babel-eslint": "^3.1.19"


### PR DESCRIPTION
I don't see why not.

See: https://github.com/facebook/react/issues/4542