### PR TITLE
Add a title attribute

### DIFF
--- a/timeago.js
+++ b/timeago.js
@@ -117,6 +117,10 @@ module.exports = React.createClass(
 
       var props = assign({}, this.props)
 
+      props.title = props.title || typeof props.date === 'string'
+        ? props.date
+        : (new Date(props.date)).toISOString().substr(0, 16).replace('T', ' ')
+
       delete props.date
       delete props.formatter
       delete props.component


### PR DESCRIPTION
One considerable usability downside of relative timestamps is taking control from the user.
`title` attribute is a small step to improve that. It’s not perfect, but it has effectively no downsides.

The format is ISO `2015-01-01 01:23` to avoid having to deal with localizations,
and yet provide a sensible default.

In case the date provided is already a string, it’s likely to be better for the user.
For an example the time portion might be missing. Since the `Date` object
unfortunately, does not represent that, we would have `00:00` in the end.
Using the input string as is is better in such scenarios.