### PR TITLE
Fix minPeriod and maxPeriod to use seconds rather than milliseconds

### DIFF
--- a/timeago.js
+++ b/timeago.js
@@ -73,7 +73,7 @@ module.exports = React.createClass(
         period = 0
       }
 
-      period = Math.min(Math.max(period, this.props.minPeriod), this.props.maxPeriod)
+      period = Math.min(Math.max(period, this.props.minPeriod * 1000), this.props.maxPeriod * 1000)
 
       if(!!period){
         this.timeoutId = setTimeout(this.tick, period)


### PR DESCRIPTION
Per documentation, minPeriod and maxPeriod are intended to use seconds by default rather than milliseconds.  Also referenced in #17.  This PR updates the code to reflect that.