### PR TITLE
Typo in willUnmount lifecycle hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
     }
   }
 
-  componentWIllUnmount () {
+  componentWillUnmount () {
     this.isStillMounted = false
     if (this.timeoutId) {
       clearTimeout(this.timeoutId)


### PR DESCRIPTION
The typo is causing timers to continue even when the component is unmounted.