### PR TITLE
Use object spread syntax instead of Object.assign()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       ? [Math.round(seconds / MONTH), 'month']
       : [Math.round(seconds / YEAR), 'year']
 
-    const props = Object.assign({}, this.props)
+    const props = {...this.props}
     props.title = props.title || typeof props.date === 'string'
       ? props.date
       : (new Date(props.date)).toISOString().substr(0, 16).replace('T', ' ')


### PR DESCRIPTION
Fixes react-timeago in IE11 and anything else which doesn't implement `Object.assign()` natively

This should also close #33