### PR TITLE
Avoid use of Object.assign() and drop unused object-assign dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,11 +52,9 @@
     "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-react": "^5.2.2",
     "eslint-plugin-standard": "^1.3.2",
-    "object-assign": "^4.1.0",
     "react": "^15.0.0-rc.2",
     "react-dom": "^15.0.0-rc.2"
   },
   "dependencies": {
-    "object-assign": "^4.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       : (new Date(date)).toISOString().substr(0, 16).replace('T', ' ')
 
     if (Komponent === 'time') {
-      Object.assign(passDownProps, {dateTime: (new Date(date)).toISOString()})
+      passDownProps.dateTime = (new Date(date)).toISOString()
     }
 
     return (


### PR DESCRIPTION
Fixes IE11 and anything else which doesn't implement Object.assign() natively