### PR TITLE
Handle undefined word separator, and fix #44, #49

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output/
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "description": "A simple Time-Ago component for ReactJs",
   "main": "lib/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "cpflow": "find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\\/src\\\//\\\/lib\\\//g'`.flow; done",
+    "test": "ava --require babel-register",
+    "cpflow": "find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`.flow; done",
     "babel": "babel src/ --out-dir lib/",
     "example": "browserify -t babelify --debug examples/simple/index.js -o examples/simple/bundle.js",
     "build": "npm run babel && npm run cpflow && npm run example",
     "prepublish": "npm run build"
   },
+	"ava": {
+		"babel": "inherit"
+	},
   "repository": {
     "type": "git",
     "url": "https://github.com/naman34/react-timeago.git"
@@ -33,6 +36,7 @@
     "react": "^0.14.0 || ^15.0.0-0"
   },
   "devDependencies": {
+    "ava": "^0.16.0",
     "babel-cli": "^6.10.1",
     "babel-eslint": "^6.1.2",
     "babel-plugin-syntax-flow": "^6.5.0",
@@ -44,6 +48,7 @@
     "babel-preset-stage-1": "^6.5.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
+    "enzyme": "^2.4.1",
     "eslint": "^3.0.1",
     "eslint-config-standard": "^5.3.1",
     "eslint-config-standard-react": "^2.5.0",
@@ -53,8 +58,8 @@
     "eslint-plugin-react": "^5.2.2",
     "eslint-plugin-standard": "^1.3.2",
     "react": "^15.0.0-rc.2",
+    "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.0.0-rc.2"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -4,16 +4,17 @@
   "description": "A simple Time-Ago component for ReactJs",
   "main": "lib/index.js",
   "scripts": {
-    "test": "ava --require babel-register",
     "cpflow": "find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`.flow; done",
     "babel": "babel src/ --out-dir lib/",
     "example": "browserify -t babelify --debug examples/simple/index.js -o examples/simple/bundle.js",
     "build": "npm run babel && npm run cpflow && npm run example",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "test": "ava --require babel-register",
+    "coverall": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
-	"ava": {
-		"babel": "inherit"
-	},
+  "ava": {
+    "babel": "inherit"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/naman34/react-timeago.git"
@@ -48,6 +49,7 @@
     "babel-preset-stage-1": "^6.5.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
+    "coveralls": "^2.11.12",
     "enzyme": "^2.4.1",
     "eslint": "^3.0.1",
     "eslint-config-standard": "^5.3.1",
@@ -57,6 +59,7 @@
     "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-react": "^5.2.2",
     "eslint-plugin-standard": "^1.3.2",
+    "nyc": "^8.0.0",
     "react": "^15.0.0-rc.2",
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.0.0-rc.2"

--- a/src/formatters/buildFormatter.js
+++ b/src/formatters/buildFormatter.js
@@ -61,7 +61,7 @@ export default function buildFormatter (strings: L10nsStrings): Formatter {
     // convert weeks to days if strings don't handle weeks
     if (unit === 'week' && !strings.week && !strings.weeks) {
       const now = Date.now()
-      const days = Math.round(Math.abs(epochSeconds - now) % (1000 * 60 * 60 * 24))
+      const days = Math.round(Math.abs(epochSeconds - now) / (1000 * 60 * 60 * 24))
       value = days
       unit = 'day'
     }

--- a/src/formatters/buildFormatter.js
+++ b/src/formatters/buildFormatter.js
@@ -99,7 +99,7 @@ export default function buildFormatter (strings: L10nsStrings): Formatter {
     }
 
     // join the array into a string and return it
-    const wordSeparator = strings.wordSeparator || ' '
+    const wordSeparator = strings.wordSeparator === undefined ? ' ' : strings.wordSeparator
     return dateString.join(wordSeparator)
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,63 @@
+import test from 'ava'
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import TimeAgo from '../src'
+import buildFormatter from '../src/formatters/buildFormatter'
+import TWStrings from '../src/language-strings/zh-TW'
+
+test('just now', t => {
+  const wrapper = shallow(<TimeAgo date={new Date()} />)
+  t.is(wrapper.text(), '0 seconds ago')
+})
+
+test('1 second ago', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 1000} />)
+  t.is(wrapper.text(), '1 second ago')
+})
+
+test('2 seconds ago', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 2000} />)
+  t.is(wrapper.text(), '2 seconds ago')
+})
+
+test('1 minute ago', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 1000 * 60} />)
+  t.is(wrapper.text(), '1 minute ago')
+})
+
+test('2 minutes ago', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 2000 * 60} />)
+  t.is(wrapper.text(), '2 minutes ago')
+})
+
+test('1 hour ago', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 1000 * 60 * 60} />)
+  t.is(wrapper.text(), '1 hour ago')
+})
+
+test('2 hours ago', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 2000 * 60 * 60} />)
+  t.is(wrapper.text(), '2 hours ago')
+})
+
+test('1 day ago', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 1000 * 60 * 60 * 24} />)
+  t.is(wrapper.text(), '1 day ago')
+})
+
+test('1 week ago', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 1000 * 60 * 60 * 24 * 7} />)
+  t.is(wrapper.text(), '1 week ago')
+})
+
+/* ... */
+
+/* zh-TW */
+const formatter = buildFormatter(TWStrings)
+
+/* 1 week ago in zh-TW */
+test('1 week ago in zh-TW', t => {
+  const wrapper = shallow(<TimeAgo date={Date.now() - 1000 * 60 * 60 * 24 * 7} formatter={formatter} />)
+  t.is(wrapper.text(), '7天之前')
+})


### PR DESCRIPTION
The first commit is a quick fix of the undefined word separator to follow the [jquery-timeago#L114-L115](https://github.com/rmm5t/jquery-timeago/blob/master/jquery.timeago.js#L114-L115). Now an empty string will not be automatically transform to a space character.

Also, there is a fix on the week bug mentioned in #44, it still need test though.