### PR TITLE
add .babelrc to .gitignore so that this will be importable in react-n…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 node_modules
 src
 examples
+.babelrc


### PR DESCRIPTION
react-native environment usually translates all files (including node_modules) with babel6.
Having a .babelrc in a dependent module messes up this process (since babel reads the local .babelrc and starts looking for presets/configs that aren't there).
(see https://github.com/facebook/react-native/issues/4062 )
