### PR TITLE
Fixed flow errors because of empty array literals

### DIFF
--- a/src/formatters/buildFormatter.js
+++ b/src/formatters/buildFormatter.js
@@ -14,7 +14,7 @@ type NumberArray = [
   string,
   string,
   string
-]
+] | []
 
 export type L10nsStrings = {
   prefixAgo?: ?StringOrFn,


### PR DESCRIPTION
This was giving me like 200 flow errors because of empty array literals on translation files.
ie: https://github.com/nmn/react-timeago/blob/master/src/language-strings/de-short.js#L22
IDK whether it's better to change the root of the error or tell flow to accept it, but for now I'm leaving this on my fork.

Thanks :+1: 