### PR TITLE
Issue #62: Default formatter to be exposed as a `next()` call

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Date is a date in the past or the future. This can be a Date Object, A UTC date-
 React-Timeago is live by default and will auto update it's value. However, if you don't want this behaviour, you can set live:false.
 
 ###### formatter (optional)
-A function that takes four arguments:
+A function that takes five arguments:
   - value : An integer value, already rounded off
   - unit : A string representing the unit in english. This could be one of:
     - 'second'
@@ -93,6 +93,7 @@ A function that takes four arguments:
     - 'ago'
     - 'from now'
   - date: The actual date you are trying to represent. Use this for a more custom format for showing your date.
+  - defaultFormatter: (Optional) A default formatter function with pre-bound values. May be used as a fallback formatting option inside a custom formatting logic.
 
 Here are some examples of what the formatter function will receive:
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.13.0",
+    "babel-register": "^6.18.0",
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "coveralls": "^2.11.12",

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export type Unit = 'second'
           | 'month'
           | 'year'
 export type Suffix = 'ago' | 'from now'
-export type Formatter = (value: number, unit: Unit, suffix: Suffix, epochSeconds: number) => string | React$Element<Object>
+export type Formatter = (value: number, unit: Unit, suffix: Suffix, epochSeconds: number, nextFormatter?: () => void) => string | React$Element<Object>
 
 export type Props = {
   /** If the component should update itself over time */
@@ -50,6 +50,13 @@ const WEEK = DAY * 7
 const MONTH = DAY * 30
 const YEAR = DAY * 365
 
+function defaultFormatter (value, unit, suffix) {
+  if (value !== 1) {
+    unit += 's'
+  }
+  return value + ' ' + unit + ' ' + suffix
+}
+
 export default class TimeAgo extends Component<DefaultProps, Props, void> {
   static displayName = 'TimeAgo';
   static defaultProps = {
@@ -57,12 +64,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
     component: 'time',
     minPeriod: 0,
     maxPeriod: Infinity,
-    formatter (value, unit, suffix) {
-      if (value !== 1) {
-        unit += 's'
-      }
-      return value + ' ' + unit + ' ' + suffix
-    }
+    formatter: defaultFormatter
   };
 
   timeoutId: ?number;
@@ -166,9 +168,11 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       passDownProps.dateTime = (new Date(date)).toISOString()
     }
 
+    const nextFormatter = defaultFormatter.bind(null, value, unit, suffix, then);
+
     return (
       <Komponent {...passDownProps} title={passDownTitle}>
-        {this.props.formatter(value, unit, suffix, then)}
+        {this.props.formatter(value, unit, suffix, then, nextFormatter)}
       </Komponent>
     )
   }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const MONTH = DAY * 30
 const YEAR = DAY * 365
 
 function defaultFormatter (value, unit, suffix) {
-  if (value !== 1) {
+  if ((value % 10 !== 1) || (value % 100 === 11)) {
     unit += 's'
   }
   return value + ' ' + unit + ' ' + suffix


### PR DESCRIPTION
Proposed addition with README.md updated.