### PR TITLE
Ignore *.flow and unused post-build files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules
 src
 examples
 .babelrc
+*.flow

--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.3.1"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "files": [
+    "index.js",
+    "language-strings/",
+    "formatters/"
+  ]
 }


### PR DESCRIPTION
- adds *.flow to npmignore
- uses npm's files param to only publish certain files/folders
- closes #54 