### PR TITLE
Work around Safari date parser silent fail on particular TZ offsets 

### DIFF
--- a/src/dateParser.js
+++ b/src/dateParser.js
@@ -1,0 +1,17 @@
+// @flow
+
+export default function dateParser (date: string | number | Date): Date {
+  let parsed = new Date(date)
+  if (!Number.isNaN(parsed.valueOf())) {
+    return parsed
+  }
+
+  let parts = date.match(/\d+/g)
+  if (parts === null || parts.length <= 2) {
+    return null
+  } else {
+    parts[1] = --parts[1]
+    let isoDate = new Date(Date.UTC(...parts))
+    return isoDate;
+  }
+}

--- a/src/dateParser.js
+++ b/src/dateParser.js
@@ -12,6 +12,6 @@ export default function dateParser (date: string | number | Date): Date {
   } else {
     parts[1] = --parts[1]
     let isoDate = new Date(Date.UTC(...parts))
-    return isoDate;
+    return isoDate
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       return
     }
 
-    const then = (new Date(this.props.date)).valueOf()
+    const then = parseDateString(this.props.date).valueOf()
     if (Number.isNaN(then)) {
       console.warn('[react-timeago] Invalid Date provided')
       return
@@ -124,6 +124,18 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
     }
   }
 
+  parseDateString (dateString) {
+    let parts = dateString.match(/\d+/g)
+    if (parts === null || parts.length <= 2) {
+      let parsed = new Date(dateString);
+      return !Number.isNaN(parsed.valueOf()) ? parsed : null
+    }
+
+    parts[1] = --parts[1]
+    let isoDate = new Date(Date.UTC(...parts))
+    return isoDate;
+  }
+
   render (): ?React$Element<*> {
     /* eslint-disable no-unused-vars */
     const {
@@ -137,7 +149,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       ...passDownProps
     } = this.props
     /* eslint-enable no-unused-vars */
-    const then = (new Date(date)).valueOf()
+    const then = parseDateString(date).valueOf()
     if (Number.isNaN(then)) {
       return null
     }
@@ -163,11 +175,11 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
     const passDownTitle = typeof title === 'undefined'
       ? (typeof date === 'string'
 	? date
-	: (new Date(date)).toISOString().substr(0, 16).replace('T', ' '))
+	: parseDateString(date).toISOString().substr(0, 16).replace('T', ' '))
       : title
 
     if (Komponent === 'time') {
-      passDownProps.dateTime = (new Date(date)).toISOString()
+      passDownProps.dateTime = parseDateString(date).toISOString()
     }
 
     const nextFormatter = defaultFormatter.bind(null, value, unit, suffix, then)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 import React, {Component} from 'react'
 import defaultFormatter from './defaultFormatter'
+import dateParser from './dateParser'
 
 export type Unit = 'second'
           | 'minute'
@@ -69,7 +70,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       return
     }
 
-    const then = this.parseDateString(this.props.date).valueOf()
+    const then = dateParser(this.props.date).valueOf()
     if (!then) {
       console.warn('[react-timeago] Invalid Date provided')
       return
@@ -124,18 +125,6 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
     }
   }
 
-  parseDateString (dateString) {
-    let parts = dateString.match(/\d+/g)
-    if (parts === null || parts.length <= 2) {
-      let parsed = new Date(dateString)
-      return !Number.isNaN(parsed.valueOf()) ? parsed : null
-    }
-
-    parts[1] = --parts[1]
-    let isoDate = new Date(Date.UTC(...parts))
-    return isoDate;
-  }
-
   render (): ?React$Element<*> {
     /* eslint-disable no-unused-vars */
     const {
@@ -149,7 +138,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       ...passDownProps
     } = this.props
     /* eslint-enable no-unused-vars */
-    const then = this.parseDateString(date).valueOf()
+    const then = dateParser(date).valueOf()
     if (!then) {
       return null
     }
@@ -175,11 +164,11 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
     const passDownTitle = typeof title === 'undefined'
       ? (typeof date === 'string'
 	? date
-	: this.parseDateString(date).toISOString().substr(0, 16).replace('T', ' '))
+	: dateParser(date).toISOString().substr(0, 16).replace('T', ' '))
       : title
 
     if (Komponent === 'time') {
-      passDownProps.dateTime = this.parseDateString(date).toISOString()
+      passDownProps.dateTime = dateParser(date).toISOString()
     }
 
     const nextFormatter = defaultFormatter.bind(null, value, unit, suffix, then)

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
   parseDateString (dateString) {
     let parts = dateString.match(/\d+/g)
     if (parts === null || parts.length <= 2) {
-      let parsed = new Date(dateString);
+      let parsed = new Date(dateString)
       return !Number.isNaN(parsed.valueOf()) ? parsed : null
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,8 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       return
     }
 
-    const then = parseDateString(this.props.date).valueOf()
-    if (Number.isNaN(then)) {
+    const then = this.parseDateString(this.props.date).valueOf()
+    if (!then) {
       console.warn('[react-timeago] Invalid Date provided')
       return
     }
@@ -149,8 +149,8 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       ...passDownProps
     } = this.props
     /* eslint-enable no-unused-vars */
-    const then = parseDateString(date).valueOf()
-    if (Number.isNaN(then)) {
+    const then = this.parseDateString(date).valueOf()
+    if (!then) {
       return null
     }
     const now = Date.now()
@@ -175,11 +175,11 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
     const passDownTitle = typeof title === 'undefined'
       ? (typeof date === 'string'
 	? date
-	: parseDateString(date).toISOString().substr(0, 16).replace('T', ' '))
+	: this.parseDateString(date).toISOString().substr(0, 16).replace('T', ' '))
       : title
 
     if (Komponent === 'time') {
-      passDownProps.dateTime = parseDateString(date).toISOString()
+      passDownProps.dateTime = this.parseDateString(date).toISOString()
     }
 
     const nextFormatter = defaultFormatter.bind(null, value, unit, suffix, then)


### PR DESCRIPTION
As described in #74, `react-timeago` renders `<!-- react-empty: x -->` on Safari and Safari on iOS when fed `ISO 8601` dates containing offsets sans colon, e.g. `2017-03-05T08:54:30+0100`. The ISO specification allows for 4 different permutations.

````
<time>Z
<time>±hh:mm
<time>±hhmm
<time>±hh
````

Safari returns `null` for `new Date(isoDateWithoutColon)`. While there seem to be many ways to work around this, `Date.UTC` is particularly convenient. May need some more testing.