### PR TITLE
remove "then" parameter from defaultFormatter bind

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,7 @@ export default class TimeAgo extends Component<DefaultProps, Props, void> {
       delete passDownProps.now
     }
 
-    const nextFormatter = defaultFormatter.bind(null, value, unit, suffix, then)
+    const nextFormatter = defaultFormatter.bind(null, value, unit, suffix)
 
     return (
       <Komponent {...passDownProps} title={passDownTitle}>


### PR DESCRIPTION
Flow has (correctly) identified this parameter as being unused.

```
node_modules/react-timeago/lib/index.js.flow:195
195:     const nextFormatter = defaultFormatter.bind(null, value, unit, suffix, then)
                                                                                ^^^^ unused function argument
                      v--------------------------------------------------------------------------------
    3: export default function defaultFormatter (value: number, unit: string, suffix: string): string {
    4:   if (value !== 1) {
    5:     unit += 's'
  ...:
    8: }
       ^ function expects no more than 3 arguments. See: node_modules/react-timeago/lib/defaultFormatter.js.flow:3
```