### PR TITLE
[Semver-Minor] Adds named exports for UNIT constants

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,12 +65,12 @@ type DefaultProps = {
   +now: () => number
 }
 
-const MINUTE = 60
-const HOUR = MINUTE * 60
-const DAY = HOUR * 24
-const WEEK = DAY * 7
-const MONTH = DAY * 30
-const YEAR = DAY * 365
+export const MINUTE = 60
+export const HOUR = MINUTE * 60
+export const DAY = HOUR * 24
+export const WEEK = DAY * 7
+export const MONTH = DAY * 30
+export const YEAR = DAY * 365
 
 export default class TimeAgo extends Component<DefaultProps, Props, void> {
   static displayName = 'TimeAgo'


### PR DESCRIPTION
Added exporting of the unit constants MINUTE, DAY, WEEK, etc. as named exports for re-use inside of client code, especially useful in custom formatters, or general re-use by dependent projects. (Otherwise these constants have to be redefined in each consuming project).

This could then be imported like so:

    import TimeAgo, { HOUR, MINUTE, SECOND } from 'react-timeago';

Because these are constants, the values cannot be redefined and cause unintended behavior in the application. This is not a breaking change: existing consumers would notice no changes since there are currently no named exports. I am open to discussion on this pull request, because I think there ought to be *some* re-use provided to consumers in their custom formatters. Another option would be to export Unit or something like that so consumers don't have to specifically name each constant they want to export.