### PR TITLE
Add es6 module build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,18 @@
 {
-  "presets": ["es2015", "react", "stage-1"]
+  "env": {
+    "development": {
+      "presets": [
+        ["es2015"],
+        "react",
+        "stage-1"
+      ]
+    },
+    "es": {
+      "presets": [
+        ["es2015", { "modules": false }],
+        "react",
+        "stage-1"
+      ]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ build/Release
 
 node_modules
 lib
+es
 
 .DS_Store
 */.DS_Store

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "3.4.3",
   "description": "A simple Time-Ago component for ReactJs",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "scripts": {
     "cpflow": "find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`.flow; done",
-    "babel": "babel src/ --out-dir lib/",
+    "babel:cjs": "babel src/ --out-dir lib/",
+    "babel:es": "BABEL_ENV=es babel src/ --out-dir es/",
     "example": "browserify -t babelify --debug examples/simple/index.js -o examples/simple/bundle.js",
-    "build": "npm run babel && npm run cpflow && npm run example",
+    "build": "npm run babel:cjs && npm run babel:es && npm run cpflow && npm run example",
     "prepublish": "npm run build",
     "test": "ava --require babel-register",
     "coverall": "nyc npm test && nyc report --reporter=text-lcov | coveralls"


### PR DESCRIPTION
This PR adds es6 module build. This allows webpack 3 to do scope hoisting when react-timeago is imported.

Alone it only saved me some 500 bytes of space. With some other components converted to es6, the space savings got much bigger.

I am not familiar with Flow, so I did not add cpflow task to this.