### PR TITLE
Fix #118, losing reference to timers.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,9 @@ export default class TimeAgo extends Component<Props> {
     )
 
     if (period) {
+      if (this.timeoutId) {
+        clearTimeout(this.timeoutId)
+      }
       this.timeoutId = setTimeout(this.tick, period)
     }
 


### PR DESCRIPTION
componentDidUpdate is calling tick, which creates a new timeout without clearing any existing ones.