### PR TITLE
Fix tr language

### DIFF
--- a/src/language-strings/tr.js
+++ b/src/language-strings/tr.js
@@ -4,8 +4,9 @@ import type { L10nsStrings } from '../formatters/buildFormatter'
 // Turkish
 const strings: L10nsStrings = {
   suffixAgo: 'önce',
-  suffixFromNow: null,
-  seconds: '1 dakikadan',
+  suffixFromNow: 'sonra',
+  second: '1 saniye',
+  seconds: '%d saniye',
   minute: '1 dakika',
   minutes: '%d dakika',
   hour: '1 saat',


### PR DESCRIPTION
Hello, thank you for creating this library. It's really useful and well made. During my usage with the Turkish language, I found that some fields in the language string is missing or incorrect. Here you can see that I updated them. 

In seconds it was; '1 dakikadan' which means, from one minute. First added the second field with value '1 saniye' which means one second in Turkish. After that, I modified the seconds field accordingly.

Lastly, I added the value 'sonra' to the suffixFromNow field.