### PR TITLE
Fix update period for dates older than a day

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,13 +90,14 @@ export default function TimeAgo({
         : seconds < HOUR
           ? 1000 * MINUTE
           : seconds < DAY
-          ? 1000 * HOUR
-          : 0
+            ? 1000 * HOUR
+            : Infinity
+
       const period = Math.min(
         Math.max(unboundPeriod, minPeriod * 1000),
         maxPeriod * 1000,
       )
-    
+
       if (period) {
         if (timeoutId) {
         clearTimeout(timeoutId)


### PR DESCRIPTION
For dates older than a day, and where `minPeriod` was set, the component updated every `minPeriod`.
With this update, dates older than a day are always decided by the `maxPeriod` option.