### PR TITLE
Fix epochMilliseconds argument; minor README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+#### v4.4.0
+- Bug Fix: clearTimeout when setting a new timeout. Prevents unnecessary renders.
+
+#### v4.2.0
+- Pass in the `now` function as the last argument to the formatters.
+- Fix a bug in `buildFormatter` that would ignore the user-specified `now` function and just used `Date.now`
+
+#### v4.2.0
+- Fixed the type of `Formatter`.
+  - It's last argument is now correctly typed to be `() => React.Node`
+  - This last argument is now a documented feature and is going to be set to the value of of the default formatter.
+  - Please Note, that you should not use this argument and instead import defaultFormatter from the package directly and use it as a fallback.
+
+#### v4.0.0 - v4.1.9:
+- Requires React ^16.
+- Flow types updated to the latest version (0.69)
+- Various bug-fixes.
+
+#### v3.x.x:
+
+- `minPeriod` and `maxPeriod` now accept seconds not milliseconds. This matches the documentation.
+- react-timeago now uses ES6 modules. So if you don't use ES6, your code will go from :
+
+```js
+var TimeAgo = require('react-timeago')
+```
+to:
+```js
+var TimeAgo = require('react-timeago').default
+```
+ES6 imports will continue to work the same way.
+```js
+import TimeAgo from 'react-timeago'
+```
+
+#### v2.2.1
+* Fixed the many typos introduced by me in 2.2.0. Thanks to insin for the quick PR.
+
+#### v2.2.0
+* FEATURE: New Props: `minPeriod` and `maxPeriod` to customize how often the Component updates.
+
+#### v2.1.1
+
+* BUG-FIX: Fixed an issue, where changing the date wouldn't correctly update the update timer.
+
+#### v2.1.0
+
+* FEATURE: Added PropType validation. It will now print a warning if you fail to pass in a date, instead of failing silently.
+* BUG-FIX: Pending Timeouts are cleared when the Component is unmounted
+* BUG-FIX: When new Props are passed in, the component will update itself correctly. Now you can flip the live switch on and off.
+* FEATURE: The formatter function gets the original date as the fourth argument, for more custom date formats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### v5.2.1
+
+- Minor documentation fixes
+
 #### v4.4.0
 - Bug Fix: clearTimeout when setting a new timeout. Prevents unnecessary renders.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A function that takes four arguments:
   - `suffix` : A string. This can be one of
     - 'ago'
     - 'from now'
-  - `epochMiliseconds`: The result of `Date.now()` or the result of a custom `now` prop.
+  - `epochMilliseconds`: The result of `Date.now()` or the result of a custom `now` prop.
   - `nextFormatter`: A function that takes no arguments and gives you the result of the defaultFormatter using the same arguments above.
 
 Here are some examples of what the formatter function will receive:

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 ![React-TimeAgo](http://naman.s3.amazonaws.com/react-timeago.png)
 
-A simple time-ago component for ReactJs.
+A simple time-ago component for [React].
 
 ## Usage:
 
-React-timeago is a very simple component that takes a date prop and returns a span with live updating date in a time-ago format. The date will update only as often as needed. For timestamps below a minute away — every second, for timestamps up to 5 minutes away — every minute, and so on.
+`react-timeago` is a very simple component that takes a `date` prop and returns a span with live updating date in a time-ago format. The date will update only as often as needed. For timestamps below a minute away — every second, for timestamps up to 5 minutes away — every minute, and so on.
 
-React-TimeAgo does the minimum amount of updates necessary.
+`react-timeago` does the minimum amount of updates necessary.
 
 ```jsx
 <TimeAgo date="Aug 29, 2014" />
 
 // OR in vanilla JS
-
 React.createElement(TimeAgo, {date: 'Aug 29, 2014'})
-
 ```
 
 ## Language support
@@ -23,7 +21,7 @@ Since v3.1.0 `react-timeago` now comes with support for a large number of langua
 This support is based on the string objects taken from `jquery-timeago` and then updated with the help of the
 community. Many thanks to all those who contribute language support.
 
-#### Usage:
+### Usage
 To use any of the languages provided, other than the default english, you will have to
 import the language strings and build a custom formatter.
 
@@ -39,7 +37,7 @@ const formatter = buildFormatter(frenchStrings)
 ```
 
 And that's it. You can also customize the language strings or provide your own.
-(Pull Requests are welcome too!). Of course, for maximum control you can write your
+(pull requests are welcome too!). Of course, for maximum control you can write your
 own formatter function.
 
 For best performance, I recommend that you build formatters that you're going to use once,
@@ -68,8 +66,8 @@ This can be specifically useful for server rendering when you want the datetime 
 
 #### `formatter` (optional)
 A function that takes four arguments:
-  - value : An integer value, already rounded off
-  - unit : A string representing the unit in english. This could be one of:
+  - `value` : An integer value, already rounded off
+  - `unit` : A string representing the unit in english. This could be one of:
     - 'second'
     - 'minute'
     - 'hour'
@@ -77,11 +75,11 @@ A function that takes four arguments:
     - 'week'
     - 'month'
     - 'year'
-  - suffix : A string. This can be one of
+  - `suffix` : A string. This can be one of
     - 'ago'
     - 'from now'
-  - epochSeconds: The result of `Date.now()` or the result of a custom `now` prop.
-  - nextFormatter: A function that takes no arguments and gives you the result of the defaultFormatter using the same arguments above.
+  - `epochMiliseconds`: The result of `Date.now()` or the result of a custom `now` prop.
+  - `nextFormatter`: A function that takes no arguments and gives you the result of the defaultFormatter using the same arguments above.
 
 Here are some examples of what the formatter function will receive:
 
@@ -119,12 +117,12 @@ This means that you can pass className, styles, id, title, aria-label, event han
 
 ## Why React-TimeAgo
 
-React-TimeAgo focusses on speed, and simplicity. At about 100 lines of code, the file size is extremely small. There are many similar libraries, but most of them come with large dependencies that aren't worth it for such a simple use case.
+React-TimeAgo focuses on speed, and simplicity. At about 100 lines of code, the file size is extremely small. There are many similar libraries, but most of them come with large dependencies that aren't worth it for such a simple use case.
 
 In the spirit of NPM and keeping libraries small, any additional features you may need from TimeAgo can be plugged-in using the formatter function.
 
 In the future, I will be writing formatter functions for various languages, that can be required and passed-in as needed.
-As you will only require the parts you actually use, there will be no need to bloat-up your JavaScript.
+As you will only require the parts you actually use, there will be no need to bloat your JavaScript.
 
 React-TimeAgo is also set apart from its competitors in that it is one of the only time-ago components that can update itself live.
 
@@ -135,65 +133,13 @@ While the code is complete and pretty stable, I welcome issues and pull requests
 
 React-TimeAgo is feature complete from my point of view (discussions welcome).
 
-However, support for various languages can always be improved. So please, contribute
-strings for the language(s) you're fluent in. I'm specifically looking for strings for
-the unit 'week'. `jquery-timeago` did not support weeks in its strings, and so in all but the
-default English, weeks get down-converted to days instead. Help me fix that.
+However, support for various languages can always be improved. So please, contribute strings for the language(s) you're fluent in. I'm specifically looking for strings for the unit 'week'. `jquery-timeago` did not support weeks in its strings, and so in all but the default English, weeks get down-converted to days instead. Help me fix that.
 
-## SemVer
+### Changelog and Versioning
 
-React-TimeAgo follows SemVer strictly.
+After contributing your feature or fix, please update the [changelog](/CHANGELOG.md) describing your change. Don't forget to version `package.json` as well, as the package follows [SemVer] strictly.
 
-## Changelog
+See [CHANGELOG.md](/CHANGELOG.md).
 
-#### v4.4.0
-- Bug Fix: clearTimeout when setting a new timeout. Prevents unnecessary renders.
-
-#### v4.2.0
-- Pass in the `now` function as the last argument to the formatters.
-- Fix a bug in `buildFormatter` that would ignore the user-specified `now` function and just used `Date.now`
-
-#### v4.2.0
-- Fixed the type of `Formatter`.
-  - It's last argument is now correctly typed to be `() => React.Node`
-  - This last argument is now a documented feature and is going to be set to the value of of the default formatter.
-  - Please Note, that you should not use this argument and instead import defaultFormatter from the package directly and use it as a fallback.
-
-#### v4.0.0 - v4.1.9:
-- Requires React ^16.
-- Flow types updated to the latest version (0.69)
-- Various bug-fixes.
-
-#### v3.x.x:
-
-- `minPeriod` and `maxPeriod` now accept seconds not milliseconds. This matches the documentation.
-- react-timeago now uses ES6 modules. So if you don't use ES6, your code will go from :
-
-```js
-var TimeAgo = require('react-timeago')
-```
-to:
-```js
-var TimeAgo = require('react-timeago').default
-```
-ES6 imports will continue to work the same way.
-```js
-import TimeAgo from 'react-timeago'
-```
-
-#### v2.2.1
-* Fixed the many typos introduced by me in 2.2.0. Thanks to insin for the quick PR.
-
-#### v2.2.0
-* FEATURE: New Props: `minPeriod` and `maxPeriod` to customize how often the Component updates.
-
-#### v2.1.1
-
-* BUG-FIX: Fixed an issue, where changing the date wouldn't correctly update the update timer.
-
-#### v2.1.0
-
-* FEATURE: Added PropType validation. It will now print a warning if you fail to pass in a date, instead of failing silently.
-* BUG-FIX: Pending Timeouts are cleared when the Component is unmounted
-* BUG-FIX: When new Props are passed in, the component will update itself correctly. Now you can flip the live switch on and off.
-* FEATURE: The formatter function gets the original date as the fourth argument, for more custom date formats.
+[React]: https://reactjs.org/
+[SemVer]: https://semver.org/

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "A simple Time-Ago component for ReactJs",
   "main": "lib/index.js",
   "scripts": {
-    "cpflow": "find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`.flow; done",
     "babel": "babel src/ --out-dir lib/",
-    "example": "browserify -t babelify --debug examples/simple/index.js -o examples/simple/bundle.js",
     "build": "npm run babel && npm run cpflow && npm run example",
+    "cpflow": "find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`.flow; done",
+    "example": "browserify -t babelify --debug examples/simple/index.js -o examples/simple/bundle.js",
     "prepublish": "npm run build",
     "test": "jest --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timeago",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "A simple Time-Ago component for ReactJs",
   "main": "lib/index.js",
   "scripts": {

--- a/src/formatters/buildFormatter.js
+++ b/src/formatters/buildFormatter.js
@@ -74,7 +74,7 @@ export default function buildFormatter(strings: L10nsStrings): Formatter {
     value: number,
     unit: Unit,
     suffix: Suffix,
-    epochMiliseconds: number,
+    epochMilliseconds: number,
     _nextFormmater: () => React.Node,
     now: () => number,
   ) {
@@ -82,7 +82,7 @@ export default function buildFormatter(strings: L10nsStrings): Formatter {
     // convert weeks to days if strings don't handle weeks
     if (unit === 'week' && !strings.week && !strings.weeks) {
       const days = Math.round(
-        Math.abs(epochMiliseconds - current) / (1000 * 60 * 60 * 24),
+        Math.abs(epochMilliseconds - current) / (1000 * 60 * 60 * 24),
       )
       value = days
       unit = 'day'
@@ -91,7 +91,7 @@ export default function buildFormatter(strings: L10nsStrings): Formatter {
     // create a normalize function for given value
     const normalize = normalizeFn(
       value,
-      current - epochMiliseconds,
+      current - epochMilliseconds,
       strings.numbers != null ? strings.numbers : undefined,
     )
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export type Formatter = (
   value: number,
   unit: Unit,
   suffix: Suffix,
-  epochMiliseconds: number,
+  epochMilliseconds: number,
   nextFormatter: () => React.Node,
   now: () => number,
 ) => React.Node
@@ -83,7 +83,7 @@ export default function TimeAgo({
       }
       const timeNow = now()
       const seconds = Math.round(Math.abs(timeNow - then) / 1000)
-    
+
       const unboundPeriod =
         seconds < MINUTE
         ? 1000
@@ -113,7 +113,7 @@ export default function TimeAgo({
       clearTimeout(timeoutId)
     }
   }, [])
-  
+
   const Komponent = component
   const then = dateParser(date).valueOf()
   if (!then) {


### PR DESCRIPTION
Love this project @nmn, thanks for authoring it! Was using it and wanted to contribute a couple small updates.

Notably:
- Moved `CHANGELOG` to its own file
- Fixed the `epochMilliseconds` argument in docs, and in code to add two `lls`
- Misc. formatting 
- Alphabetized npm scripts