### PR TITLE
Move eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "babel-jest": "^26.3.0",
+    "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-flowtype": "^5.7.2",
     "eslint-plugin-import": "^2.23.2",
@@ -66,9 +67,7 @@
     "react-dom": "^17.0.2",
     "rollup": "^2.48.0"
   },
-  "dependencies": {
-    "eslint": "^7.26.0"
-  },
+  "dependencies": {},
   "prettier": {
     "printWidth": 80,
     "parser": "flow",


### PR DESCRIPTION
I think this was inadvertently added to `dependencies` in edfe4f669210417c99546510829d3e660e511ccb.