### PR TITLE
Fix refresh creating an infinite timeout loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timeago",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "A simple Time-Ago component for ReactJs",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ export default function TimeAgo({
   component = 'time',
   live = true,
   minPeriod = 0,
-  maxPeriod = Infinity,
+  maxPeriod = WEEK,
   title,
   now = () => Date.now(),
   ...passDownProps
@@ -90,14 +90,14 @@ export default function TimeAgo({
           ? 1000 * MINUTE
           : seconds < DAY
           ? 1000 * HOUR
-          : Infinity
+          : 1000 * WEEK
 
       const period = Math.min(
         Math.max(unboundPeriod, minPeriod * 1000),
         maxPeriod * 1000,
       )
 
-      if (period && period !== Infinity) {
+      if (period) {
         if (timeoutId) {
           clearTimeout(timeoutId)
         }

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ export default function TimeAgo({
         maxPeriod * 1000,
       )
 
-      if (period) {
+      if (period && period !== Infinity) {
         if (timeoutId) {
           clearTimeout(timeoutId)
         }


### PR DESCRIPTION
If the date is more than a week away, then the refresh period would be set to `Infinity`. This gets passed to a `setTimeout`, which fires immediately causing a refresh loop, which in my instance resulted in 100% cpu usage.

It could also be the cause of https://github.com/nmn/react-timeago/issues/160

The code already does a true-y check on period before issuing the setTimeout, this patch also explicitly checks for Infinity to ensure that the timeout doesn't fire

Infinite timeouts are a bit of a js quirk that really don't behave as expected - https://github.com/denysdovhan/wtfjs#an-infinite-timeout