### PR TITLE
support for fuzzy intervals

### DIFF
--- a/src/language-strings/en-fuzzy-short.js
+++ b/src/language-strings/en-fuzzy-short.js
@@ -1,0 +1,24 @@
+/* @flow */
+import type { L10nsStrings } from '../formatters/buildFormatter'
+
+// English shortened
+const strings: L10nsStrings = {
+  prefixAgo: null,
+  prefixFromNow: null,
+  suffixAgo: '',
+  suffixFromNow: '',
+  seconds: 'just now',
+  minute: '1m',
+  minutes: '%dm',
+  hour: '1h',
+  hours: '%dh',
+  day: '1d',
+  days: '%dd',
+  month: '1mo',
+  months: '%dmo',
+  year: '1yr',
+  years: '%dyr',
+  wordSeparator: ' ',
+}
+
+export default strings

--- a/src/language-strings/en-fuzzy.js
+++ b/src/language-strings/en-fuzzy.js
@@ -1,0 +1,24 @@
+/* @flow */
+import type { L10nsStrings } from '../formatters/buildFormatter'
+
+// English (Template)
+const strings: L10nsStrings = {
+  prefixAgo: null,
+  prefixFromNow: null,
+  suffixAgo: 'ago',
+  suffixFromNow: 'from now',
+  seconds: 'a moment',
+  minute: 'about a minute',
+  minutes: '%d minutes',
+  hour: 'about an hour',
+  hours: 'about %d hours',
+  day: 'a day',
+  days: '%d days',
+  month: 'about a month',
+  months: '%d months',
+  year: 'about a year',
+  years: '%d years',
+  wordSeparator: ' ',
+}
+
+export default strings


### PR DESCRIPTION
## Verbose Fuzzy
```js
import TimeAgo from 'react-timeago'
import fuzzyStrings from 'react-timeago/lib/language-strings/en-fuzzy'
import buildFormatter from 'react-timeago/lib/formatters/buildFormatter'

const formatter = buildFormatter(fuzzyStrings)

// "a moment ago" -> "about a minute ago" -> "2 minutes ago" -> ...
<TimeAgo date={Date.now()} formatter={formatter} />
```

## Short Fuzzy
```js
import TimeAgo from 'react-timeago'
import fuzzyShortStrings from 'react-timeago/lib/language-strings/en-fuzzy-short' // "just now"
import buildFormatter from 'react-timeago/lib/formatters/buildFormatter'

const formatter = buildFormatter(fuzzyShortStrings)

// "just now" -> "1m" -> "2m" -> ...
<TimeAgo date={Date.now()} formatter={formatter} />
```

---
see: #172 