### PR TITLE
Fix timeNow not being updated if props change frequently

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,13 @@ export default function TimeAgo({
   ...passDownProps
 }: Props): null | React.MixedElement {
   const [timeNow, setTimeNow] = useState(now())
+  const updateNoLaterThan = useRef(null)
+
+  if(updateNoLaterThan.current && Date.now() > updateNoLaterThan.current){
+    updateNoLaterThan.current = null
+    setTimeNow(now())
+  }
+
   useEffect(() => {
     if (!live) {
       return
@@ -96,7 +103,11 @@ export default function TimeAgo({
       )
 
       if (period) {
+        if(updateNoLaterThan.current == null){
+          updateNoLaterThan.current = now() + period + 100
+        }
         return setTimeout(() => {
+          updateNoLaterThan.current = null
           setTimeNow(now())
         }, period)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ export default function TimeAgo({
       )
 
       if (period) {
-        if(updateNoLaterThan.current == null){
+        if(updateNoLaterThan.current === null){
           updateNoLaterThan.current = now() + period + 100
         }
         return setTimeout(() => {


### PR DESCRIPTION
I've ran into an issue when the date prop is changed more frequently than the refresh interval. Each
time the date prop changes, the timeout that triggers the updated of timeNow is cancelled & a fresh one is computed.
If this happens often enough then the component won't recalculate timeNow for extended periods of time so the result displayed is inaccurate

This codepen demonstrates the issue: https://codepen.io/fcheung/pen/QWmKJgm

It has a minPeriod of 6s and the date passed to TimeAgo is set to the current date every 3 seconds - time ago
should never display a distance of more than a few seconds, but it counts up in an unbounded way.

Not sure if this is the best way to fix this but this PR seems to do the trick for me - I use a ref to store when we expect timeNow to be updated (plus a small amount of buffer). If the function is re-rendered after that point then recompute timeNow straightaway