### PR TITLE
Fix time not updating when period is longer than component re-render time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,8 @@ const WEEK = DAY * 7
 const MONTH = DAY * 30
 const YEAR = DAY * 365
 
+const defaultNow = () => Date.now();
+
 export default function TimeAgo({
   date,
   formatter = defaultFormatter,
@@ -65,7 +67,7 @@ export default function TimeAgo({
   minPeriod = 0,
   maxPeriod = WEEK,
   title,
-  now = () => Date.now(),
+  now = defaultNow,
   ...passDownProps
 }: Props): null | React.MixedElement {
   const [timeNow, setTimeNow] = useState(now())


### PR DESCRIPTION
The `now` function is a dependency in the `useEffect`; as a result, whenever `now` changes, the previous timeout gets cleared and a new timeout gets queued.

The problem with this is, since the default value of `now` was within the component: `now = () => Date.now()`, if the `TimeAgo` component ever re-renders, the `now` function would end up with a new function reference, and the `useEffect` would be triggered.

In my use case, `TimeAgo` was a child component of a parent that would re-render every ~5 seconds. 
- When the date is less than 1 minute ago, the refresh period would be every second, so the timeouts would always trigger as expected
- However, when the date is greater than 1 minute ago, the refresh period becomes 60 seconds, but since my component was re-rendering every ~5 seconds, the timeouts would never end up triggering since they would be cleared after each re-render, so the time label wouldn't ever update past 1 minute

By moving the default `now` definition outside the scope of the component, the `now` function won't have a new reference after each re-render, which fixes the issue.