### PR TITLE
Fix Korean "seconds" string

### DIFF
--- a/src/language-strings/ko.js
+++ b/src/language-strings/ko.js
@@ -7,7 +7,7 @@ const strings: L10nsStrings = {
   prefixFromNow: null,
   suffixAgo: '전',
   suffixFromNow: '후',
-  seconds: '방금',
+  seconds: '몇 초',
   minute: '약 1분',
   minutes: '%d분',
   hour: '약 1시간',


### PR DESCRIPTION
https://github.com/nmn/react-timeago/pull/60 changed "1분" to "방금" which is unfortunately only half correct. ("1분" means "1 minute" as opposed to "less than a minute", which I imagine was why the new translation was suggested.)

For `seconds` + `suffixAgo`, it's fine.
"방금 전" = "a moment ago"

For `seconds` + `suffixFromNow`, it is wrong.
"방금 후" does not make sense.

"몇 초" means "several seconds", works with both suffixes, and sounds natural for native speakers. Variants of direct translations of "less than a minute" were considered and are not technically wrong (e.g., "1분 미만 전"), but they sound very awkward.