### PR TITLE
Refresh timeNow even before the first tick

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,10 +72,12 @@ export default function TimeAgo({
 }: Props): null | React.MixedElement {
   const [timeNow, setTimeNow] = useState(now())
   useEffect(() => {
+    if (live) setTimeNow(now())
+  }, [date, live, now])
+  useEffect(() => {
     if (!live) {
       return
     }
-    setTimeNow(now());
     const tick = (): 0 | TimeoutID => {
       const then = dateParser(date).valueOf()
       if (!then) {

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ export default function TimeAgo({
     if (!live) {
       return
     }
+    setTimeNow(now());
     const tick = (): 0 | TimeoutID => {
       const then = dateParser(date).valueOf()
       if (!then) {


### PR DESCRIPTION
Without this fix, when I run code similar to the one in #181 (i.e. displaying the amount of time that has passed since the button was clicked, which is _always_ in the past of course), then it displays "within a few seconds" at first, and only after a second (after the first tick fires) it updates to the correct "a few seconds ago". That's because right after the button click, `date` has already been moved forward, but `timeNow` has not. The change of `date` triggers the `useEffect`, but that doesn't trigger a `timeNow` update until the first tick fired. Therefore, add a `timeNow` update immediately as well.