### PR TITLE
Handled invalid formatter function props being passed

### DIFF
--- a/__tests__/formatter-value-tests.js
+++ b/__tests__/formatter-value-tests.js
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import TimeAgo from '../src'
+
+test('1 minute ago', () => {
+  render(<TimeAgo date={Date.now() - 1000 * 60} />)
+  expect(screen.getByText('1 minute ago')).toBeInTheDocument()
+})
+
+it('should handle null formatter gracefully', () => {
+  render(<TimeAgo date={Date.now() - 1000 * 60} formatter={null} />)
+  expect(screen.getByText('1 minute ago')).toBeInTheDocument()
+})
+
+it('should handle empty function formatter', () => {
+  render(<TimeAgo date={Date.now() - 2000 * 60 * 60} formatter={() => {}} />)
+  expect(screen.getByText('2 hours ago')).toBeInTheDocument()
+})
+
+it('should handle formatter throwing an error', () => {
+  render(
+    <TimeAgo
+      date={Date.now() - 2000 * 60}
+      formatter={() => {
+        throw new Error('Faulty formatter')
+      }}
+    />,
+  )
+  expect(screen.getByText('2 minutes ago')).toBeInTheDocument()
+})

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ const WEEK = DAY * 7
 const MONTH = DAY * 30
 const YEAR = DAY * 365
 
-const defaultNow = () => Date.now();
+const defaultNow = () => Date.now()
 
 export default function TimeAgo({
   date,
@@ -153,11 +153,40 @@ export default function TimeAgo({
       ? { ...passDownProps, dateTime: dateParser(date).toISOString() }
       : passDownProps
 
-  const nextFormatter = defaultFormatter.bind(null, value, unit, suffix)
+  // const nextFormatter = defaultFormatter.bind(null, value, unit, suffix)
 
+  const nextFormatter = (value, unit, suffix) => {
+    // Use the default formatter if `formatter` is not a valid function or if it doesn't behave correctly
+    if (typeof formatter !== 'function') {
+      console.warn(
+        '[react-timeago] Formatter is not a function. Using default formatter.',
+      )
+      return defaultFormatter(value, unit, suffix, then, nextFormatter, now)
+    }
+
+    try {
+      // Call the formatter to see if it behaves correctly
+      const result = formatter(value, unit, suffix, then, nextFormatter, now)
+      // If the result is falsy, fall back to defaultFormatter
+      if (!result) {
+        console.warn(
+          '[react-timeago] Formatter is invalid. Using default formatter.',
+        )
+        return defaultFormatter(value, unit, suffix, then, nextFormatter, now)
+      }
+      return result
+    } catch (error) {
+      console.warn(
+        '[react-timeago] Formatter is invalid. Using default formatter.',
+        error,
+      )
+      return defaultFormatter(value, unit, suffix, then, nextFormatter, now)
+    }
+  }
   return (
     <Komponent {...spreadProps} title={passDownTitle}>
-      {formatter(value, unit, suffix, then, nextFormatter, now)}
+      {/* {formatter(value, unit, suffix, then, nextFormatter, now)} */}
+      {nextFormatter(value, unit, suffix)}
     </Komponent>
   )
 }


### PR DESCRIPTION
**Problems**

1. When the formatter prop is provided as a value that is not a function (e.g., null, undefined, or a non-callable object), the component raises an exception indicating that "formatter is not a function." This results in a stack trace being logged, which exposes the internal error and disrupts the user experience.

2. When a valid function is provided to the formatter prop, if that function throws an error during execution, it leads to an unhandled exception that crashes the application. This prevents the TimeAgo component from rendering as intended, impacting the overall functionality and user interface.


**Solutions**
1. Implemented a check to determine if the formatter is a function. If it is not, a warning is logged, and the component falls back to using the defaultFormatter. This ensures that the component can still render valid output without crashing.

2. Wrapped the call to the formatter in a try-catch block to catch any errors that may arise during its execution. If an error is thrown, a warning is logged, and the component gracefully falls back to the defaultFormatter.


Ensured all test cases pass
