### PR TITLE
Package.json : Allow access to language-strings and formatters files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "exports": {
     ".": {
       "import": "./es6/index.js",
-      "require": "./lib/index.js"
+      "require": "./lib/index.js",
+      "./lib/language-strings/*": "./lib/language-strings/*.js",
+      "./lib/formatters/*": "./lib/formatters/*.js"
     }
   },
   "module": "es6/index.js",


### PR DESCRIPTION
Quick fix for issue https://github.com/nmn/react-timeago/issues/213 by updating the `exports` field in ` package.json` allowing  direct import of language-strings and formatter files

This restores compatibility for projects relying on these internal modules before the exports field was introduced.