### PR TITLE
fix: fix exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,14 @@
       "import": "./es6/index.js",
       "require": "./lib/index.js"
     },
-    "./lib/language-strings/*": "./lib/language-strings/*.js",
-    "./lib/formatters/*": "./lib/formatters/*.js"
+    "./lib/language-strings/*": {
+      "import": "./es6/language-strings/*",
+      "require": "./lib/language-strings/*"
+    },
+    "./lib/formatters/buildFormatter": {
+      "import": "./es6/formatters/buildFormatter.js",
+      "require": "./lib/formatters/buildFormatter.js"
+    }
   },
   "module": "es6/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,25 @@
       "import": "./es6/index.js",
       "require": "./lib/index.js"
     },
+    "./dateParser": {
+      "import": "./es6/dateParser.js",
+      "require": "./lib/dateParser.js"
+    },
+    "./defaultFormatter": {
+      "import": "./es6/defaultFormatter.js",
+      "require": "./lib/defaultFormatter.js"
+    },
+    "./language-strings/*": {
+      "import": "./es6/language-strings/*.js",
+      "require": "./lib/language-strings/*.js"
+    },
+    "./formatters/buildFormatter": {
+      "import": "./es6/formatters/buildFormatter.js",
+      "require": "./lib/formatters/buildFormatter.js"
+    },
     "./lib/language-strings/*": {
-      "import": "./es6/language-strings/*",
-      "require": "./lib/language-strings/*"
+      "import": "./es6/language-strings/*.js",
+      "require": "./lib/language-strings/*.js"
     },
     "./lib/formatters/buildFormatter": {
       "import": "./es6/formatters/buildFormatter.js",


### PR DESCRIPTION
Fixes #213 

- Improves the exports declaration to correctly handle both CJS and ESM exports.
- Still need to check if I need to change the file extension for the files under `es6` to `.mjs`. (Help appreciated)