### PR TITLE
Export Formatter, Unit and Suffix types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### v8.3.0
+- Exported Formatter, Unit, and Suffix types which were present in v7
+
 #### v8.1.0
 - Fixed bug where `nextFormatter` no longer worked without passing arguments
   - Calling `nextFormatter()` without arguments should work once again.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timeago",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "A simple Time-Ago component for ReactJs",
   "main": "lib/index.js",
   "types": "es6/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { useEffect, useState } from 'react'
 import dateParser from './dateParser'
 import defaultFormatter from './defaultFormatter'
-import type { Formatter, Suffix, Unit } from './types'
+export type { Formatter, Suffix, Unit } from './types'
 
 export type Props = $ReadOnly<{
   /** If the component should update itself over time */


### PR DESCRIPTION
Fixes #230 

This PR exports `Formatter`, `Unit` and `Suffix` types which were present in v7. Now you can do this again:

```typescript
import type { Formatter, Suffix, Unit } from 'react-timeago';

const myCustomFormatter: Formatter = (
  value: number,
  unit: Unit,
  suffix: Suffix,
  epochMilliseconds: number,
  nextFormatter: Formatter,
  now: () => number,
) => {
  if (suffix === 'from now' || unit === 'second') return 'just now';
  if (nextFormatter) return nextFormatter(value, unit, suffix, epochMilliseconds, nextFormatter, now);
  return '';
};
```